### PR TITLE
Local cartesian and Geocentric projectors

### DIFF
--- a/lanelet2_projection/CHANGELOG.rst
+++ b/lanelet2_projection/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package lanelet2_projection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.1.2 (2022-02-18)
+------------------
+* Add LocalCartesian projector to better handle altitude
+* Contributors: Michal Antkiewicz
+
 1.1.1 (2020-09-14)
 ------------------
 

--- a/lanelet2_projection/include/lanelet2_projection/Geocentric.h
+++ b/lanelet2_projection/include/lanelet2_projection/Geocentric.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <lanelet2_io/Exceptions.h>
+#include <lanelet2_io/Projection.h>
+
+#include <GeographicLib/Geocentric.hpp>
+
+namespace lanelet {
+namespace projection {
+
+class GeocentricProjector : public Projector {
+ public:
+  BasicPoint3d forward(const GPSPoint& gps) const override;
+  GPSPoint reverse(const BasicPoint3d& enu) const override;
+};
+
+}  // namespace projection
+}  // namespace lanelet

--- a/lanelet2_projection/include/lanelet2_projection/LocalCartesian.h
+++ b/lanelet2_projection/include/lanelet2_projection/LocalCartesian.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <lanelet2_io/Exceptions.h>
+#include <lanelet2_io/Projection.h>
+
+#include <GeographicLib/Geocentric.hpp>
+#include <GeographicLib/LocalCartesian.hpp>
+
+namespace lanelet {
+namespace projection {
+class LocalCartesianProjector : public Projector {
+ public:
+  explicit LocalCartesianProjector(Origin origin);
+
+  BasicPoint3d forward(const GPSPoint& gps) const override;
+
+  GPSPoint reverse(const BasicPoint3d& enu) const override;
+ private:
+  GeographicLib::LocalCartesian localCartesian;
+};
+
+}  // namespace projection
+}  // namespace lanelet

--- a/lanelet2_projection/package.xml
+++ b/lanelet2_projection/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>lanelet2_projection</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>Lanelet2 projection library for lat/lon to local x/y conversion</description>
 
   <license>BSD</license>
@@ -10,6 +10,7 @@
   <author email="maximilian.naumann@kit.edu">Maximilian Naumann</author>
   <author email="fabian.poggenhans@kit.edu">Fabian Poggenhans</author>
   <author email="jan-hendrik.pauls@kit.edu">Jan-Hendrik Pauls</author>
+  <author email="michal.antkiewicz@uwaterloo.ca">Michal Antkiewicz</author>
   <url type="repository">https://github.com/fzi-forschungszentrum-informatik/lanelet2.git</url>
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>

--- a/lanelet2_projection/src/Geocentric.cpp
+++ b/lanelet2_projection/src/Geocentric.cpp
@@ -1,0 +1,29 @@
+#include "lanelet2_projection/Geocentric.h"
+
+namespace lanelet {
+namespace projection {
+
+BasicPoint3d GeocentricProjector::forward(const GPSPoint& gps) const {
+  BasicPoint3d ecef{0., 0., 0.};
+  GeographicLib::Geocentric::WGS84().Forward(gps.lat,
+                                           gps.lon,
+                                           gps.ele,
+                                           ecef[0],
+                                           ecef[1],
+                                           ecef[2]);
+  return ecef;
+}
+
+GPSPoint GeocentricProjector::reverse(const BasicPoint3d& ecef) const {
+  GPSPoint gps{0., 0., 0.};
+  GeographicLib::Geocentric::WGS84().Reverse(ecef[0],
+                                           ecef[1],
+                                           ecef[2],
+                                           gps.lat,
+                                           gps.lon,
+                                           gps.ele);
+  return gps;
+}
+
+}  // namespace projection
+}  // namespace lanelet

--- a/lanelet2_projection/src/LocalCartesian.cpp
+++ b/lanelet2_projection/src/LocalCartesian.cpp
@@ -21,7 +21,7 @@ BasicPoint3d LocalCartesianProjector::forward(const GPSPoint& gps) const {
 
 GPSPoint LocalCartesianProjector::reverse(const BasicPoint3d& local) const {
   GPSPoint gps{0., 0., 0.};
-  this->localCartesian.Forward(local[0],
+  this->localCartesian.Reverse(local[0],
                                local[1],
                                local[2],
                                gps.lat,

--- a/lanelet2_projection/src/LocalCartesian.cpp
+++ b/lanelet2_projection/src/LocalCartesian.cpp
@@ -1,0 +1,34 @@
+#include "lanelet2_projection/LocalCartesian.h"
+
+namespace lanelet {
+namespace projection {
+
+LocalCartesianProjector::LocalCartesianProjector(Origin origin) :
+      Projector(origin),
+      localCartesian(origin.position.lat, origin.position.lon, origin.position.ele, GeographicLib::Geocentric::WGS84()) {
+}
+
+BasicPoint3d LocalCartesianProjector::forward(const GPSPoint& gps) const {
+  BasicPoint3d local{0., 0., 0.};
+  this->localCartesian.Forward(gps.lat,
+                               gps.lon,
+                               gps.ele,
+                               local[0],
+                               local[1],
+                               local[2]);
+  return local;
+}
+
+GPSPoint LocalCartesianProjector::reverse(const BasicPoint3d& local) const {
+  GPSPoint gps{0., 0., 0.};
+  this->localCartesian.Forward(local[0],
+                               local[1],
+                               local[2],
+                               gps.lat,
+                               gps.lon,
+                               gps.ele);
+  return gps;
+}
+
+}  // namespace projection
+}  // namespace lanelet

--- a/lanelet2_python/python_api/projection.cpp
+++ b/lanelet2_python/python_api/projection.cpp
@@ -16,7 +16,7 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
          bases<Projector>>("MercatorProjector", init<Origin>("origin"));
   class_<projection::LocalCartesianProjector, std::shared_ptr<projection::LocalCartesianProjector>,  // NOLINT
          bases<Projector>>("LocalCartesianProjector", init<Origin>("origin"));
-  class_<projection::UtmProjector, std::shared_ptr<projection::UtmProjector>, bases<Projector>>("UtmProjector",
-                                                                                                init<Origin>("origin"))
+  class_<projection::UtmProjector, std::shared_ptr<projection::UtmProjector>,  // NOLINT
+         bases<Projector>>("UtmProjector", init<Origin>("origin"))
       .def(init<Origin, bool, bool>("UtmProjector(origin, useOffset, throwInPaddingArea)"));
 }

--- a/lanelet2_python/python_api/projection.cpp
+++ b/lanelet2_python/python_api/projection.cpp
@@ -1,4 +1,5 @@
 #include <lanelet2_projection/UTM.h>
+#include <lanelet2_projection/LocalCartesian.h>
 
 #include <boost/python.hpp>
 
@@ -13,6 +14,8 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .def("origin", &Projector::origin, "Global origin of the converter", return_internal_reference<>());
   class_<projection::SphericalMercatorProjector, std::shared_ptr<projection::SphericalMercatorProjector>,  // NOLINT
          bases<Projector>>("MercatorProjector", init<Origin>("origin"));
+  class_<projection::LocalCartesianProjector, std::shared_ptr<projection::LocalCartesianProjector>,  // NOLINT
+         bases<Projector>>("LocalCartesianProjector", init<Origin>("origin"));
   class_<projection::UtmProjector, std::shared_ptr<projection::UtmProjector>, bases<Projector>>("UtmProjector",
                                                                                                 init<Origin>("origin"))
       .def(init<Origin, bool, bool>("UtmProjector(origin, useOffset, throwInPaddingArea)"));

--- a/lanelet2_python/python_api/projection.cpp
+++ b/lanelet2_python/python_api/projection.cpp
@@ -1,4 +1,5 @@
 #include <lanelet2_projection/UTM.h>
+#include <lanelet2_projection/Geocentric.h>
 #include <lanelet2_projection/LocalCartesian.h>
 
 #include <boost/python.hpp>
@@ -14,6 +15,8 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .def("origin", &Projector::origin, "Global origin of the converter", return_internal_reference<>());
   class_<projection::SphericalMercatorProjector, std::shared_ptr<projection::SphericalMercatorProjector>,  // NOLINT
          bases<Projector>>("MercatorProjector", init<Origin>("origin"));
+  class_<projection::GeocentricProjector, std::shared_ptr<projection::GeocentricProjector>,  // NOLINT
+         bases<Projector>>("GeocentricProjector");
   class_<projection::LocalCartesianProjector, std::shared_ptr<projection::LocalCartesianProjector>,  // NOLINT
          bases<Projector>>("LocalCartesianProjector", init<Origin>("origin"));
   class_<projection::UtmProjector, std::shared_ptr<projection::UtmProjector>,  // NOLINT


### PR DESCRIPTION
The UTM projector creates shifts in projected maps relative to actual world positions. 

Added Geocentric (ECEF) and  LocalCartesian projectors from geographic lib as available projectors.

These projectors have the advantage over the UTM projector in that they properly use lat/lon/alt to compute XYZ using WGS84 ellipsoid, whereas the UTM projector only uses lat/lon to convert into X/Y/Z on the ellipsoid and just adds elevation, which is incorrect. 

![image](https://user-images.githubusercontent.com/439625/155998695-bcffac0e-bdce-478c-a151-20109f47f3ba.png)

In the image above, the point P' is the shifted point created by the UTM projector, compared to the correct point P.